### PR TITLE
Update README with run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Aggregated Search Demo
 
-Run the Go server to start.
+This demo aggregates search results from several engines.
+
+## Prerequisites
+
+- Go **1.20** or later must be installed.
+
+## Running
+
+Start the server directly with `go run`:
+
+```bash
+go run ./cmd/server
+```
+
+Once the server is running, open [http://localhost:8080](http://localhost:8080) in your browser to access the app.


### PR DESCRIPTION
## Summary
- document Go 1.20+ requirement
- add direct `go run` command
- mention opening <http://localhost:8080>

## Testing
- `go test ./...`
